### PR TITLE
Fix crash when an object was injected

### DIFF
--- a/arduino-iot-cloud.js
+++ b/arduino-iot-cloud.js
@@ -447,14 +447,14 @@ module.exports = function (RED) {
   RED.httpAdmin.get("/properties", RED.auth.needsPermission('Property-in.read'), async function (req, res) {
     return getThingsOrProperties(req, res, "properties");
   });
-}
 
-function getStatus(value) {
-  if (typeof value !== "object") {
-    if (typeof value === "number" && !(Number.isInteger(value)))
-      return value.toFixed(3);
-    else
-      return value;
+  function getStatus(value) {
+    if (typeof value !== "object") {
+      if (typeof value === "number" && !(Number.isInteger(value)))
+        return value.toFixed(3);
+      else
+        return value;
+    }
+    return RED._("arduino-iot-cloud.status.object-injected");
   }
-  return RED._("arduino-iot-cloud.status.object-injected");
 }


### PR DESCRIPTION
RED object inside getStatus was not defined because the function was out the main object