### PR TITLE
FIX: Publish data to Cloud including Device ID

### DIFF
--- a/arduino-iot-cloud.js
+++ b/arduino-iot-cloud.js
@@ -82,9 +82,26 @@ module.exports = function (RED) {
               this.thing = config.thing;
               this.propertyId = config.property;
               this.propertyName = config.name;
+
+              //console.log("Node Constructor: ", config.name);
+              try {
+                const opts = {}
+                if (this.organization) {
+                  opts.xOrganization = this.organization;
+                }
+                ret = await this.arduinoRestClient.getThing(this.thing, opts);
+                this.device_id = ret.device_id;
+                //console.log("  Thing info: ", JSON.stringify(ret));
+                //console.log("  Device ID: ", this.device_id);
+              } catch (error) {
+                // Handle API call error
+                console.error('Error making API call:', error.message);
+              }
+
+              
               this.on('input', async function (msg) {
                 try {
-                  await this.arduinoRestClient.setProperty(this.thing, this.propertyId, msg.payload);
+                  await this.arduinoRestClient.setProperty(this.thing, this.propertyId, msg.payload, this.device_id);
                   var s;
                   if (typeof msg.payload !== "object") {
                     s = getStatus(msg.payload);

--- a/utils/arduino-iot-cloud-api-wrapper.js
+++ b/utils/arduino-iot-cloud-api-wrapper.js
@@ -40,9 +40,10 @@ class ArduinoClientHttp {
   updateToken(token) {
     this.token = token;
   }
-  setProperty(thing_id, property_id, value) {
+  setProperty(thing_id, property_id, value, device_id = undefined) {
     const body = JSON.stringify({
-      value: value
+      value: value,
+      device_id : device_id
     });
     oauth2.accessToken = this.token;
     return apiProperties.propertiesV2Publish(thing_id, property_id, body);
@@ -50,6 +51,11 @@ class ArduinoClientHttp {
   getThings(opts) {
     oauth2.accessToken = this.token;
     return apiThings.thingsV2List(opts);
+  }
+  getThing(thingId, opts) {
+    oauth2.accessToken = this.token;
+    opts.showDeleted = false;
+    return apiThings.thingsV2Show(thingId, opts);
   }
   getProperties(thingId, opts) {
     oauth2.accessToken = this.token;


### PR DESCRIPTION
If the Device ID is included in the `propertiesV2Publish` API call, data is updated in real time in the Arduino Cloud and so, it can be visualized in real time in the dashboards.

In this PR, the Device ID is obtained in the constructor of the Output nodes and it is used later on every `setProperty()` call (that ultimately calls `propertiesV2Publish`).

Note:
* If connectivity to the Cloud fails on startup, Device ID will never get updated. To fix this, an alternative approach to this PR would be to verify each time before calling setProperty if the Device ID has been initialized and if not, try to get it. 