### PR TITLE
Add the send as device option to output node

### DIFF
--- a/arduino-iot-cloud.html
+++ b/arduino-iot-cloud.html
@@ -52,6 +52,10 @@
             ret['variableName'] = {value: ""};
         }
 
+        if (nodeName === "property out") {
+            ret['sendasdevice'] = {value: false};
+        }
+
         return ret;
     }
 
@@ -99,6 +103,10 @@
                             initThings(connection, this._);
                         }
                     }
+                });
+                $("#node-input-sendasdevice").change(() => {
+                    sendasdevice = $("#node-input-sendasdevice").val();
+                    this.sendasdevice = sendasdevice;
                 });
                 $("#node-input-organization").change(() => {
                     const connection = $("#node-input-connection").val();
@@ -381,6 +389,10 @@
   <div class="form-row">
       <label for="node-input-name"><i class="fa fa-tag fa-fw"></i><span data-i18n="arduino-iot-cloud.config.node.name"></span></label>
       <input type="text" id="node-input-name" data-i18n="[placeholder]arduino-iot-cloud.config.node.placeholders.name">
+  </div>
+    <div class="form-row">
+      <label for="node-input-name"><i class="fa fa-tag fa-fw"></i><span data-i18n="arduino-iot-cloud.config.node.send-mode"></span></label>
+      <input type="checkbox" id="node-input-sendasdevice">
   </div>
 
 </script>

--- a/arduino-iot-cloud.js
+++ b/arduino-iot-cloud.js
@@ -82,9 +82,25 @@ module.exports = function (RED) {
               this.thing = config.thing;
               this.propertyId = config.property;
               this.propertyName = config.name;
+              this.sendasdevice = config.sendasdevice;
+
+              if (this.sendasdevice) {
+                try {
+                  const opts = {}
+                  if (this.organization) {
+                    opts.xOrganization = this.organization;
+                  }
+                  ret = await this.arduinoRestClient.getThing(this.thing, opts);
+                  this.device_id = ret.device_id;
+                } catch (error) {
+                  // Handle API call error
+                  console.error('Error making API call:', error.message);
+                }
+              }
+              
               this.on('input', async function (msg) {
                 try {
-                  await this.arduinoRestClient.setProperty(this.thing, this.propertyId, msg.payload);
+                  await this.arduinoRestClient.setProperty(this.thing, this.propertyId, msg.payload, this.sendasdevice ? this.device_id : undefined);
                   var s;
                   if (typeof msg.payload !== "object") {
                     s = getStatus(msg.payload);

--- a/locales/en-US/arduino-iot-cloud.json
+++ b/locales/en-US/arduino-iot-cloud.json
@@ -9,6 +9,7 @@
         "organization": "Space ID",
         "hist-label":"Time filter",
         "poll-label":"Poll Every",
+        "send-mode":"Send as device",
         "placeholders":{
           "name":"Name",
           "no-thing-selected":"No thing selected",


### PR DESCRIPTION
This PR introduces the possibility, for the output node, to send a payload to the cloud "As a device". In this new use case, the use can check the option "Send as device" in order to use the Arduino API to mock a message sent by the device. 

This new option covers the use case of a node-red workflow used to update the dashboard without a device actually connected to the cloud (we can call it, node-red device simulation).

IMPORTANT NOTE: If the option is checked the message is sent "As if the message is sent directly from the device", so if there is an actual device connected, the device will not receive the message. So we have to keep this mode optional.