### PR TITLE
Add the send as device option to output node

### DIFF
--- a/arduino-iot-cloud.html
+++ b/arduino-iot-cloud.html
@@ -54,6 +54,7 @@
 
         if (nodeName === "property out") {
             ret['sendasdevice'] = {value: false};
+            ret["device"] = {value: ""};
         }
 
         return ret;
@@ -83,6 +84,7 @@
                     }
                     initThings(this.connection, this._, this.thing, this.organization);
                     initProperties(this.connection, this.thing, this.organization, this.property, outs, this._);
+                    initDevice(this.connection, this.thing.id, this.organization, this._);
                 }
                 $("select#node-input-connection").change((e) => {
                     var msg = this._("arduino-iot-cloud.config.connection.placeholders.no-conn-selected");
@@ -105,8 +107,16 @@
                     }
                 });
                 $("#node-input-sendasdevice").change(() => {
-                    sendasdevice = $("#node-input-sendasdevice").val();
-                    this.sendasdevice = sendasdevice;
+                    if ($("#node-input-sendasdevice").is(":checked")) {
+                        const connection = $("#node-input-connection").val();
+                        const thing_id = $("#node-input-thing").val();
+                        const organization = $("#node-input-organization").val();
+                        initDevice(connection, thing_id, organization, this._);
+                        $("#node-input-device-line").show()
+                    } else {
+                        $("#node-input-device-line").hide()
+                        $("#node-input-device").val("");
+                    }
                 });
                 $("#node-input-organization").change(() => {
                     const connection = $("#node-input-connection").val();
@@ -143,6 +153,7 @@
                         } else {
                             $("select#node-input-property").empty();
                             initProperties(connection, thing_id, organization, this.property, outs, this._);
+                            initDevice(connection, thing_id, organization, this._);
                         }
                     }
                 });
@@ -249,6 +260,30 @@
         } else if ($.ajaxSettings.headers) {
             delete $.ajaxSettings.headers.organization
         }
+    }
+
+    function initDevice(connection, thing_id, organization_id, label_func) {
+        let queryString = prepareQueryString(connection);
+        if (!queryString || queryString === "")
+            return;
+        if (!thing_id || thing_id === "" || thing_id === "0" || thing_id === "updating")
+            return;
+        queryString = `${queryString}&thing_id=${thing_id}`;
+
+        $("select#node-input-device").empty();
+        $("<option value='" + "updating" + "'> " + "" + "</option>").appendTo("#node-input-device");
+        $("select#node-input-device").val("updating");
+
+        setupOrganization(organization_id);
+        $.getJSON(`thing?${queryString}`, thing => {
+            $("select#node-input-device").empty();
+            msg = label_func("arduino-iot-cloud.config.node.placeholders.device-select");
+            $("<option value='" + "" + "'> " + msg + "</option>").appendTo("#node-input-device");
+            if(thing){
+                $("<option value='" + thing.device_id + "'>" + thing.device_name + "</option>").appendTo("#node-input-device");
+                $("select#node-input-device").val(thing.device_id);
+            }
+        });
     }
 
     function initProperties(connection, thing_id, organization_id, property_id, outs, label_func) {
@@ -394,7 +429,11 @@
       <label for="node-input-name"><i class="fa fa-tag fa-fw"></i><span data-i18n="arduino-iot-cloud.config.node.send-mode"></span></label>
       <input type="checkbox" id="node-input-sendasdevice">
   </div>
-
+  <div class="form-row" id="node-input-device-line">
+    <label for="node-input-device"><i class="fa fa-cube fa-fw"></i> <span data-i18n="arduino-iot-cloud.config.node.device-id"></span></label>
+    <select id="node-input-device" type="hidden" data-i18n="[placeholder]arduino-iot-cloud.config.node.placeholders.device-select">
+    </select>
+  </div>
 </script>
 
 

--- a/arduino-iot-cloud.html
+++ b/arduino-iot-cloud.html
@@ -25,6 +25,11 @@
         return (v !== null && v !== undefined && v !== "" && v !== "err");
     }
 
+    function validateDevice(v) {
+        const sendasdevice = $("#node-input-sendasdevice").is(":checked")
+        return !sendasdevice || (v !== null && v !== undefined && v !== "" && v !== "err");
+    }
+
     function validateConnection(v) {
         return (v !== null && v !== undefined && v !== "" && v !== "_ADD_");
     }
@@ -54,7 +59,7 @@
 
         if (nodeName === "property out") {
             ret['sendasdevice'] = {value: false};
-            ret["device"] = {value: ""};
+            ret["device"] = {value: "", validate: validateDevice};
         }
 
         return ret;
@@ -84,7 +89,6 @@
                     }
                     initThings(this.connection, this._, this.thing, this.organization);
                     initProperties(this.connection, this.thing, this.organization, this.property, outs, this._);
-                    initDevice(this.connection, this.thing.id, this.organization, this._);
                 }
                 $("select#node-input-connection").change((e) => {
                     var msg = this._("arduino-iot-cloud.config.connection.placeholders.no-conn-selected");
@@ -107,15 +111,17 @@
                     }
                 });
                 $("#node-input-sendasdevice").change(() => {
-                    if ($("#node-input-sendasdevice").is(":checked")) {
-                        const connection = $("#node-input-connection").val();
-                        const thing_id = $("#node-input-thing").val();
-                        const organization = $("#node-input-organization").val();
-                        initDevice(connection, thing_id, organization, this._);
-                        $("#node-input-device-line").show()
-                    } else {
-                        $("#node-input-device-line").hide()
-                        $("#node-input-device").val("");
+                    const thing_id = $("#node-input-thing").val();
+                    if (thing_id) {
+                        if ($("#node-input-sendasdevice").is(":checked")) {
+                            const connection = $("#node-input-connection").val();
+                            const organization = $("#node-input-organization").val();
+                            const device = $("#node-input-device").val();
+                            initDevice(connection, thing_id, organization, device, this._);
+                            $("#node-input-device-line").show()
+                        } else {
+                            $("#node-input-device-line").hide()
+                        }
                     }
                 });
                 $("#node-input-organization").change(() => {
@@ -137,6 +143,7 @@
                     const property_id = $("#node-input-property").val();
                     const connection = $("#node-input-connection").val();
                     const organization = $("#node-input-organization").val();
+                    const device = $("#node-input-device").val();
                     const thing_text = $("#node-input-thing").find('option:selected').text()
                     var str;
                     if (connection === "_ADD_") {
@@ -153,7 +160,7 @@
                         } else {
                             $("select#node-input-property").empty();
                             initProperties(connection, thing_id, organization, this.property, outs, this._);
-                            initDevice(connection, thing_id, organization, this._);
+                            initDevice(connection, thing_id, organization, this.device, this._);
                         }
                     }
                 });
@@ -240,6 +247,7 @@
                     $("#node-input-thing").val(thing_id);
                 }
                 $("#node-input-thing").trigger("change");
+                $("#node-input-sendasdevice").trigger("change");
             } else if (things && Array.isArray(things) && things.length === 0) {
                 $("select#node-input-thing").empty();
                 msg = label_func("arduino-iot-cloud.config.node.placeholders.no-things-available");
@@ -262,12 +270,13 @@
         }
     }
 
-    function initDevice(connection, thing_id, organization_id, label_func) {
+    function initDevice(connection, thing_id, organization_id, device_id, label_func) {
         let queryString = prepareQueryString(connection);
-        if (!queryString || queryString === "")
+        if (!queryString || queryString === "") 
             return;
         if (!thing_id || thing_id === "" || thing_id === "0" || thing_id === "updating")
             return;
+
         queryString = `${queryString}&thing_id=${thing_id}`;
 
         $("select#node-input-device").empty();
@@ -277,11 +286,15 @@
         setupOrganization(organization_id);
         $.getJSON(`thing?${queryString}`, thing => {
             $("select#node-input-device").empty();
-            msg = label_func("arduino-iot-cloud.config.node.placeholders.device-select");
-            $("<option value='" + "" + "'> " + msg + "</option>").appendTo("#node-input-device");
-            if(thing){
-                $("<option value='" + thing.device_id + "'>" + thing.device_name + "</option>").appendTo("#node-input-device");
+            if(thing && typeof (thing) == "object" && thing.error){
+                $("select#node-input-device").empty();
+                $("<option value='" + "" + "'> " + properties.error + "</option>").appendTo("select#node-input-device");
+            } else if (thing.device_id) {
+                $("<option value='" + thing.device_id + "'>" + thing.device_name + "</option>").appendTo("select#node-input-device");
                 $("select#node-input-device").val(thing.device_id);
+            } else {
+                msg = label_func("arduino-iot-cloud.config.node.placeholders.no-device-select");
+                $("<option value='" + "" + "' > " + msg + "</option>").appendTo("select#node-input-device");
             }
         });
     }
@@ -431,7 +444,7 @@
   </div>
   <div class="form-row" id="node-input-device-line">
     <label for="node-input-device"><i class="fa fa-cube fa-fw"></i> <span data-i18n="arduino-iot-cloud.config.node.device-id"></span></label>
-    <select id="node-input-device" type="hidden" data-i18n="[placeholder]arduino-iot-cloud.config.node.placeholders.device-select">
+    <select id="node-input-device" type="hidden" data-i18n="[placeholder]arduino-iot-cloud.config.node.placeholders.no-device-select">
     </select>
   </div>
 </script>

--- a/arduino-iot-cloud.html
+++ b/arduino-iot-cloud.html
@@ -52,6 +52,10 @@
             ret['variableName'] = {value: ""};
         }
 
+        if (nodeName === "property out") {
+            ret['sendasdevice'] = {value: false};
+        }
+
         return ret;
     }
 
@@ -99,6 +103,10 @@
                             initThings(connection, this._);
                         }
                     }
+                });
+                $("#node-input-sendasdevice").change(() => {
+                    sendasdevice = $("#node-input-sendasdevice").val();
+                    this.sendasdevice = sendasdevice;
                 });
                 $("#node-input-organization").change(() => {
                     const connection = $("#node-input-connection").val();
@@ -381,6 +389,10 @@
   <div class="form-row">
       <label for="node-input-name"><i class="fa fa-tag fa-fw"></i><span data-i18n="arduino-iot-cloud.config.node.name"></span></label>
       <input type="text" id="node-input-name" data-i18n="[placeholder]arduino-iot-cloud.config.node.placeholders.name">
+  </div>
+    <div class="form-row">
+      <label for="node-input-name"><i class="fa fa-tag fa-fw"></i><span data-i18n="arduino-iot-cloud.config.node.send-mode"></span></label>
+      <input type="checkbox" id="node-input-sendasdevice">
   </div>
 
 </script>

--- a/arduino-iot-cloud.js
+++ b/arduino-iot-cloud.js
@@ -82,26 +82,25 @@ module.exports = function (RED) {
               this.thing = config.thing;
               this.propertyId = config.property;
               this.propertyName = config.name;
+              this.sendasdevice = config.sendasdevice;
 
-              //console.log("Node Constructor: ", config.name);
-              try {
-                const opts = {}
-                if (this.organization) {
-                  opts.xOrganization = this.organization;
+              if (this.sendasdevice) {
+                try {
+                  const opts = {}
+                  if (this.organization) {
+                    opts.xOrganization = this.organization;
+                  }
+                  ret = await this.arduinoRestClient.getThing(this.thing, opts);
+                  this.device_id = ret.device_id;
+                } catch (error) {
+                  // Handle API call error
+                  console.error('Error making API call:', error.message);
                 }
-                ret = await this.arduinoRestClient.getThing(this.thing, opts);
-                this.device_id = ret.device_id;
-                //console.log("  Thing info: ", JSON.stringify(ret));
-                //console.log("  Device ID: ", this.device_id);
-              } catch (error) {
-                // Handle API call error
-                console.error('Error making API call:', error.message);
               }
-
               
               this.on('input', async function (msg) {
                 try {
-                  await this.arduinoRestClient.setProperty(this.thing, this.propertyId, msg.payload, this.device_id);
+                  await this.arduinoRestClient.setProperty(this.thing, this.propertyId, msg.payload, this.sendasdevice ? this.device_id : undefined);
                   var s;
                   if (typeof msg.payload !== "object") {
                     s = getStatus(msg.payload);

--- a/arduino-iot-cloud.js
+++ b/arduino-iot-cloud.js
@@ -83,24 +83,13 @@ module.exports = function (RED) {
               this.propertyId = config.property;
               this.propertyName = config.name;
               this.sendasdevice = config.sendasdevice;
-
-              if (this.sendasdevice) {
-                try {
-                  const opts = {}
-                  if (this.organization) {
-                    opts.xOrganization = this.organization;
-                  }
-                  ret = await this.arduinoRestClient.getThing(this.thing, opts);
-                  this.device_id = ret.device_id;
-                } catch (error) {
-                  // Handle API call error
-                  console.error('Error making API call:', error.message);
-                }
-              }
+              this.device = config.device
               
               this.on('input', async function (msg) {
                 try {
-                  await this.arduinoRestClient.setProperty(this.thing, this.propertyId, msg.payload, this.sendasdevice ? this.device_id : undefined);
+                  console.log("dev_id", this.device);
+                  console.log("send_device", this.sendasdevice);
+                  await this.arduinoRestClient.setProperty(this.thing, this.propertyId, msg.payload, this.sendasdevice ? this.device : undefined);
                   var s;
                   if (typeof msg.payload !== "object") {
                     s = getStatus(msg.payload);
@@ -459,7 +448,15 @@ module.exports = function (RED) {
           opts.xOrganization = organization;
         }
         return res.send(JSON.stringify(await arduinoRestClient.getProperties(thing_id, opts)));
-      } else {
+      } else if (thingsOrProperties === "device") {
+        const thing_id = req.query.thing_id;
+        const organization = req.headers.organization;
+        const opts = {}
+        if (organization) {
+          opts.xOrganization = organization;
+        }
+        return res.send(JSON.stringify(await arduinoRestClient.getThing(thing_id, opts)));
+      }else {
         str=RED._("arduino-iot-cloud.connection-error.wrong-param");
         console.log(str);
         return res.send(JSON.stringify({ error: str }));
@@ -476,6 +473,10 @@ module.exports = function (RED) {
 
   RED.httpAdmin.get("/properties", RED.auth.needsPermission('Property-in.read'), async function (req, res) {
     return getThingsOrProperties(req, res, "properties");
+  });
+
+  RED.httpAdmin.get("/thing", RED.auth.needsPermission('Property-in.read'), async function (req, res) {
+    return getThingsOrProperties(req, res, "device");
   });
 
   function getStatus(value) {

--- a/arduino-iot-cloud.js
+++ b/arduino-iot-cloud.js
@@ -87,8 +87,6 @@ module.exports = function (RED) {
               
               this.on('input', async function (msg) {
                 try {
-                  console.log("dev_id", this.device);
-                  console.log("send_device", this.sendasdevice);
                   await this.arduinoRestClient.setProperty(this.thing, this.propertyId, msg.payload, this.sendasdevice ? this.device : undefined);
                   var s;
                   if (typeof msg.payload !== "object") {

--- a/arduino-iot-cloud.js
+++ b/arduino-iot-cloud.js
@@ -82,9 +82,26 @@ module.exports = function (RED) {
               this.thing = config.thing;
               this.propertyId = config.property;
               this.propertyName = config.name;
+
+              //console.log("Node Constructor: ", config.name);
+              try {
+                const opts = {}
+                if (this.organization) {
+                  opts.xOrganization = this.organization;
+                }
+                ret = await this.arduinoRestClient.getThing(this.thing, opts);
+                this.device_id = ret.device_id;
+                //console.log("  Thing info: ", JSON.stringify(ret));
+                //console.log("  Device ID: ", this.device_id);
+              } catch (error) {
+                // Handle API call error
+                console.error('Error making API call:', error.message);
+              }
+
+              
               this.on('input', async function (msg) {
                 try {
-                  await this.arduinoRestClient.setProperty(this.thing, this.propertyId, msg.payload);
+                  await this.arduinoRestClient.setProperty(this.thing, this.propertyId, msg.payload, this.device_id);
                   var s;
                   if (typeof msg.payload !== "object") {
                     s = getStatus(msg.payload);

--- a/locales/en-US/arduino-iot-cloud.json
+++ b/locales/en-US/arduino-iot-cloud.json
@@ -20,7 +20,7 @@
           "property-select":"Select a property",
           "no-property-available":"No properties available",
           "no-property-writable-av":"No writable properties available",
-          "device-select":"No device associated"
+          "no-device-select":"No device associated"
         }
       },
       "time":{

--- a/locales/en-US/arduino-iot-cloud.json
+++ b/locales/en-US/arduino-iot-cloud.json
@@ -9,6 +9,7 @@
         "organization": "Space ID",
         "hist-label":"Time filter",
         "poll-label":"Poll Every",
+        "send-mode":"Send as device",
         "placeholders":{
           "name":"Name",
           "no-thing-selected":"No thing selected",

--- a/locales/en-US/arduino-iot-cloud.json
+++ b/locales/en-US/arduino-iot-cloud.json
@@ -9,6 +9,7 @@
         "organization": "Space ID",
         "hist-label":"Time filter",
         "poll-label":"Poll Every",
+        "device-id": "Device",
         "send-mode":"Send as device",
         "placeholders":{
           "name":"Name",
@@ -18,7 +19,8 @@
           "no-things-available":"No things available",
           "property-select":"Select a property",
           "no-property-available":"No properties available",
-          "no-property-writable-av":"No writable properties available"
+          "no-property-writable-av":"No writable properties available",
+          "device-select":"No device associated"
         }
       },
       "time":{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arduino/node-red-contrib-arduino-iot-cloud",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@arduino/node-red-contrib-arduino-iot-cloud",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "GNU AFFERO GENERAL PUBLIC LICENSE",
       "dependencies": {
         "@arduino/arduino-iot-client": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arduino/node-red-contrib-arduino-iot-cloud",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Node-RED nodes to talk to Arduino IoT Cloud",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/utils/arduino-iot-cloud-api-wrapper.js
+++ b/utils/arduino-iot-cloud-api-wrapper.js
@@ -40,9 +40,10 @@ class ArduinoClientHttp {
   updateToken(token) {
     this.token = token;
   }
-  setProperty(thing_id, property_id, value) {
+  setProperty(thing_id, property_id, value, device_id = undefined) {
     const body = JSON.stringify({
-      value: value
+      value: value,
+      device_id : device_id
     });
     oauth2.accessToken = this.token;
     return apiProperties.propertiesV2Publish(thing_id, property_id, body);
@@ -50,6 +51,11 @@ class ArduinoClientHttp {
   getThings(opts) {
     oauth2.accessToken = this.token;
     return apiThings.thingsV2List(opts);
+  }
+  getThing(thingId, opts) {
+    oauth2.accessToken = this.token;
+    opts.showDeleted = false;
+    return apiThings.thingsV2Show(thingId, opts);
   }
   getProperties(thingId, opts) {
     oauth2.accessToken = this.token;


### PR DESCRIPTION
This PR introduces the possibility, for the output node, to send a payload to the cloud "As a device". In this new use case, the user can check the option "Send as device" in order to use the Arduino API to mock a message sent by the device.

This new option covers the use case of a node-red workflow used to update the dashboard without a device actually connected to the cloud (we can call it, node-red device simulation).

IMPORTANT NOTE: If the option is checked the message is sent "As if the message is sent directly from the device", so if there is an actual device connected, the device will not receive the message. So we have to keep this mode optional.