### PR TITLE
feat: token refresh only in case of errors

### DIFF
--- a/arduino-iot-client-mqtt/arduino-iot-client-mqtt.js
+++ b/arduino-iot-client-mqtt/arduino-iot-client-mqtt.js
@@ -627,6 +627,9 @@ class ArduinoClientMqtt {
       node=nodeId;
     }
     const propOutputTopic = `/a/t/${thingId}/e/o`;
+    if (!this.propertyCallback[propOutputTopic] || !this.propertyCallback[propOutputTopic][name]) {
+      return Promise.resolve(this.numSubscriptions);
+    }
     var pos=-1;
     for(var i=0; i<this.propertyCallback[propOutputTopic][name].length; i++){
       var cbObject=this.propertyCallback[propOutputTopic][name][i];

--- a/arduino-iot-client-mqtt/arduino-iot-client-mqtt.js
+++ b/arduino-iot-client-mqtt/arduino-iot-client-mqtt.js
@@ -230,7 +230,7 @@ class ArduinoClientMqtt {
   }
 
   async reconnect() {
-    await this.connection.reconnect();
+    this.connection.reconnect();
   };
 
   async updateToken(token) {
@@ -241,7 +241,7 @@ class ArduinoClientMqtt {
       try {
         if (this.connection) {
           // Disconnect to the connection that is using the old token
-          await this.connection.end();
+          this.connection.end();
 
           // Remove the connection
           this.connection = null;

--- a/arduino-iot-cloud.js
+++ b/arduino-iot-cloud.js
@@ -75,7 +75,7 @@ module.exports = function (RED) {
         try {
 
           if (config.thing !== "" && config.property !== "") {
-            this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig, this.organization);
+            this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig, config.organization);
             if (this.arduinoRestClient){
               this.arduinoRestClient.openConnections++;
               this.organization = config.organization;
@@ -152,7 +152,7 @@ module.exports = function (RED) {
       this.timeWindowUnit = config.timeWindowUnit;
       if (connectionConfig && config.thing !== "" && config.thing !== "0" && config.property !== "" && config.property !== "0") {
         try {
-          this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig, this.organization);
+          this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig, config.organization);
           if (this.arduinoRestClient){
             this.arduinoRestClient.openConnections++;
             if (config.thing !== "" && config.property !== "") {
@@ -251,7 +251,7 @@ module.exports = function (RED) {
       this.organization = config.organization;
       if (connectionConfig && config.thing !== "" && config.thing !== "0" && config.property !== "" && config.property !== "0") {
         try {
-          this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig, this.organization);
+          this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig, config.organization);
           if (this.arduinoRestClient){
             this.arduinoRestClient.openConnections++;
             if (config.thing !== "" && config.property !== "") {
@@ -340,7 +340,7 @@ module.exports = function (RED) {
         try {
 
           if (config.thing !== "" && config.property !== "") {
-            this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig, this.organization);
+            this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig, config.organization);
             if (this.arduinoRestClient){
               this.arduinoRestClient.openConnections++;
               this.organization = config.organization;

--- a/arduino-iot-cloud.js
+++ b/arduino-iot-cloud.js
@@ -476,7 +476,7 @@ module.exports = function (RED) {
       }
     } catch (err) {
       str=RED._("arduino-iot-cloud.connection-error.wrong-cred-sys-unvail");
-      console.log(`Status: ${err.status}, message: ${err.error}`);
+      console.log(`getThingsOrProperties status: ${err.status}, message: ${err.error} (error: ${err})`);
       return res.send(JSON.stringify({ error: str }));
     }
   }

--- a/utils/arduino-connection-manager.js
+++ b/utils/arduino-connection-manager.js
@@ -196,7 +196,7 @@ function findUser(connections, clientId) {
 async function waitForToken(connectionConfig, organizationID) {
   let delay = 200;
   while (true) {
-    let token = await getToken(connectionConfig);
+    let token = await getToken(connectionConfig, organizationID);
     if (token) {
       return token;
     }
@@ -205,7 +205,7 @@ async function waitForToken(connectionConfig, organizationID) {
   }
 }
 
-async function getToken(connectionConfig) {
+async function getToken(connectionConfig, organizationID) {
   const dataToSend = {
       grant_type: 'client_credentials',
       client_id: connectionConfig.credentials.clientid,

--- a/utils/arduino-connection-manager.js
+++ b/utils/arduino-connection-manager.js
@@ -198,7 +198,7 @@ async function waitForToken(connectionConfig, organizationID) {
   while (true) {
     let token = await getToken(connectionConfig);
     if (token) {
-      return token.token;
+      return token;
     }
     await new Promise((resolve) => setTimeout(resolve, delay));
     delay = Math.min(delay * 2, 5000);
@@ -225,9 +225,8 @@ async function getToken(connectionConfig) {
 
     var res = await req.send(dataToSend);
     var token = res.body.access_token;
-    var expires_in = res.body.expires_in;
     if (token !== undefined) {
-      return { token: token, expires_in: expires_in };
+      return token;
     }
   } catch (err) {
     if(err.response && err.response.res){

--- a/utils/arduino-connection-manager.js
+++ b/utils/arduino-connection-manager.js
@@ -46,6 +46,7 @@ var httpConnections = [];
 
 function getMqttOptions(clientId, token, RED){
    async function reconnect() {
+    console.log('Reconnecting to MQTT');
     const releaseMutex = await mqttMutex.acquire();
     let id = findUser(mqttConnections, clientId);
     if (id !== -1) {
@@ -66,6 +67,8 @@ function getMqttOptions(clientId, token, RED){
         }
       });
 
+      console.log('Disconnected from MQTT');
+
       await new Promise((resolve) => setTimeout(resolve, 1000));
       await reconnect();
     },
@@ -77,6 +80,8 @@ function getMqttOptions(clientId, token, RED){
         }
       });
 
+      console.log('Offline from MQTT');
+
       await new Promise((resolve) => setTimeout(resolve, 1000));
       await reconnect();
     },
@@ -87,6 +92,8 @@ function getMqttOptions(clientId, token, RED){
           node.status({});
         }
       });
+
+      console.log('Connected to MQTT'); 
     },
     useCloudProtocolV2: true
   };
@@ -114,11 +121,10 @@ async function getClientMqtt(connectionConfig, RED) {
     } else {
       clientMqtt = mqttConnections[id].clientMqtt;
     }
-    releaseMutex();
-
     return clientMqtt;
   } catch (err) {
     console.log(err);
+  } finally {
     releaseMutex();
   }
 }
@@ -141,20 +147,10 @@ async function getClientHttp(connectionConfig, organizationID) {
     } else {
       clientHttp = httpConnections[id].clientHttp;
     }
-    releaseMutex();
-
     return clientHttp;
   } catch (err) {
-    if(err.response && err.response.res && err.response.request){
-      console.log('statusCode: '+ err.response.res.statusCode +'\r'+
-      'statusMessage: ' + err.response.res.statusMessage + '\r' +
-      'text: ' + err.response.res.text + '\r'+
-      'HTTP method: ' + err.response.request.method + '\r' +
-      'URL request: ' + err.response.request.url
-      );
-    }else{
-      console.log(err);
-    }
+    console.log(err);
+  } finally {
     releaseMutex();
   }
 }

--- a/utils/arduino-iot-cloud-api-wrapper.js
+++ b/utils/arduino-iot-cloud-api-wrapper.js
@@ -30,46 +30,69 @@ const apiSeries = new ArduinoIotClient.SeriesV2Api(client);
 const apiThings = new ArduinoIotClient.ThingsV2Api(client);
 
 class ArduinoClientHttp {
-  constructor(token) {
-    this.token = token;
+  constructor(getToken) {
     this.openConnections=0;
+    oauth2.accessToken = "";
     if(process.env.API_BASE_PATH){
       client.basePath = process.env.API_BASE_PATH;
     }
+    
+    // Wrap the functions with refresh token logic 
+    function withTokenRefresh(fn) {
+      return async (...args) => {
+        let delay = 0;
+        for (;;) {
+          try {
+            return await fn(...args);
+          } catch (e) {
+            if (e.status === 401) {
+              oauth2.accessToken = await getToken();
+              await new Promise((resolve) => setTimeout(resolve, delay));
+              delay = delay===0 ? 200 : Math.min(delay*2, 5000);
+              continue;
+            }
+            throw e;
+          }
+        }
+      };
+    }
+    this.wrappedPropertiesV2Publish = withTokenRefresh(apiProperties.propertiesV2Publish.bind(apiProperties));
+    this.wrappedThingsV2List = withTokenRefresh(apiThings.thingsV2List.bind(apiThings));
+    this.wrappedThingsV2Show = withTokenRefresh(apiThings.thingsV2Show.bind(apiThings));
+    this.wrappedPropertiesV2Show = withTokenRefresh(apiProperties.propertiesV2Show.bind(apiProperties));
+    this.wrappedSeriesV2BatchQueryRaw = withTokenRefresh(apiSeries.seriesV2BatchQueryRaw.bind(apiSeries));
   }
-  updateToken(token) {
-    this.token = token;
-  }
-  setProperty(thing_id, property_id, value, opts, device_id = undefined) {
+
+
+  async setProperty(thing_id, property_id, value, opts = {}, device_id = undefined) {
     const body = JSON.stringify({
       value: value,
-      device_id : device_id
+      device_id: device_id
     });
-    oauth2.accessToken = this.token;
-    return apiProperties.propertiesV2Publish(thing_id, property_id, body, opts);
+    return await this.wrappedPropertiesV2Publish(thing_id, property_id, body, opts);
   }
-  getThings(opts) {
-    oauth2.accessToken = this.token;
-    return apiThings.thingsV2List(opts);
-  }
-  getThing(thingId, opts) {
-    oauth2.accessToken = this.token;
-    opts.showDeleted = false;
-    return apiThings.thingsV2Show(thingId, opts);
-  }
-  getProperties(thingId, opts) {
-    oauth2.accessToken = this.token;
-    opts.showProperties = true;
-    const thing = apiThings.thingsV2Show(thingId, opts);
-    return thing.then(({properties}) => properties);
-  }
-  getProperty(thingId, propertyId, opts) {
-    oauth2.accessToken = this.token;
-    return apiProperties.propertiesV2Show(thingId, propertyId, opts);
-  }
-  getSeries(thingId, propertyId, start, end, opts) {
 
-    const body =  JSON.stringify({
+  async getThings(opts = {}) {
+    return await this.wrappedThingsV2List(opts);
+  }
+
+  async getThing(thingId, opts = {}) {
+    opts.showDeleted = false;
+    return await this.wrappedThingsV2Show(thingId, opts);
+  }
+
+  async getProperties(thingId, opts = {}) {
+    opts.showProperties = true;
+    const { properties } = await this.wrappedThingsV2Show(thingId, opts);
+    return properties;
+  }
+
+  async getProperty(thingId, propertyId, opts = {}) {
+    return await this.wrappedPropertiesV2Show(thingId, propertyId, opts);
+  }
+
+  async getSeries(_thingId, propertyId, start, end, opts = {}) {
+    const body = JSON.stringify({
       requests: [{
         q: "property." + propertyId,
         from: start,
@@ -79,8 +102,8 @@ class ArduinoClientHttp {
       }],
       resp_version: 1
     });
-    oauth2.accessToken = this.token;
-    return apiSeries.seriesV2BatchQueryRaw(body, opts);
+    return await this.wrappedSeriesV2BatchQueryRaw(body, opts);
   }
 }
+
 exports.ArduinoClientHttp = ArduinoClientHttp;

--- a/utils/arduino-iot-cloud-api-wrapper.js
+++ b/utils/arduino-iot-cloud-api-wrapper.js
@@ -40,19 +40,16 @@ class ArduinoClientHttp {
     // Wrap the functions with refresh token logic 
     function withTokenRefresh(fn) {
       return async (...args) => {
-        let delay = 0;
-        for (;;) {
-          try {
-            return await fn(...args);
-          } catch (e) {
-            if (e.status === 401) {
-              oauth2.accessToken = await getToken();
-              await new Promise((resolve) => setTimeout(resolve, delay));
-              delay = delay===0 ? 200 : Math.min(delay*2, 5000);
-              continue;
+        try {
+          return await fn(...args);
+        } catch (e) {
+          if (e.status === 401) {
+            oauth2.accessToken = await getToken();
+            if (oauth2.accessToken) {
+              return await fn(...args);
             }
-            throw e;
           }
+          throw e;
         }
       };
     }


### PR DESCRIPTION
Remove the auto token refresh timeout of the MQTT client and HTTP client. Indeed, before this change, the tokens were refreshed every 5 minutes, no matter what. This will forcefully disconnect the MQTT client and potentially flood the broker with connection attempts if the refresh job fails and stops working.

With this PR, both token refreshes are done only in case of errors, particularly after an MQTT disconnection or a 401 error in the HTTP request.