### PR TITLE
fix: add the organization header to the token request for http nodes

### DIFF
--- a/arduino-iot-cloud.js
+++ b/arduino-iot-cloud.js
@@ -75,7 +75,7 @@ module.exports = function (RED) {
         try {
 
           if (config.thing !== "" && config.property !== "") {
-            this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig);
+            this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig, this.organization);
             if (this.arduinoRestClient){
               this.arduinoRestClient.openConnections++;
               this.organization = config.organization;
@@ -152,7 +152,7 @@ module.exports = function (RED) {
       this.timeWindowUnit = config.timeWindowUnit;
       if (connectionConfig && config.thing !== "" && config.thing !== "0" && config.property !== "" && config.property !== "0") {
         try {
-          this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig);
+          this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig, this.organization);
           if (this.arduinoRestClient){
             this.arduinoRestClient.openConnections++;
             if (config.thing !== "" && config.property !== "") {
@@ -251,7 +251,7 @@ module.exports = function (RED) {
       this.organization = config.organization;
       if (connectionConfig && config.thing !== "" && config.thing !== "0" && config.property !== "" && config.property !== "0") {
         try {
-          this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig);
+          this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig, this.organization);
           if (this.arduinoRestClient){
             this.arduinoRestClient.openConnections++;
             if (config.thing !== "" && config.property !== "") {
@@ -340,7 +340,7 @@ module.exports = function (RED) {
         try {
 
           if (config.thing !== "" && config.property !== "") {
-            this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig);
+            this.arduinoRestClient = await connectionManager.getClientHttp(connectionConfig, this.organization);
             if (this.arduinoRestClient){
               this.arduinoRestClient.openConnections++;
               this.organization = config.organization;
@@ -432,7 +432,7 @@ module.exports = function (RED) {
             clientid: req.query.clientid,
             clientsecret: req.query.clientsecret
           }
-        });
+        }, this.organization);
       } else if (req.query.connectionid) {
         const connectionConfig = RED.nodes.getNode(req.query.connectionid);
         if (!connectionConfig) {
@@ -440,7 +440,7 @@ module.exports = function (RED) {
           console.log(str);
           return res.send(JSON.stringify({ error: str }));
         }
-        arduinoRestClient = await connectionManager.getClientHttp(connectionConfig);
+        arduinoRestClient = await connectionManager.getClientHttp(connectionConfig, this.organization);
       } else {
         str=RED._("arduino-iot-cloud.connection-error.no-cred-available");
         console.log(str);

--- a/utils/arduino-connection-manager.js
+++ b/utils/arduino-connection-manager.js
@@ -40,7 +40,7 @@ const getClientMutex = new Mutex();
 var numRetry=0;
 
 
-async function getToken(connectionConfig) {
+async function getToken(connectionConfig, organizationID) {
   const dataToSend = {
       grant_type: 'client_credentials',
       client_id: connectionConfig.credentials.clientid,
@@ -49,12 +49,16 @@ async function getToken(connectionConfig) {
   };
 
   try {
+    var req = superagentsuperagent
+      .post(accessTokenUri)
+      .set('content-type', 'application/x-www-form-urlencoded')
+      .set('accept', 'json')
 
-    var res = await superagent
-              .post(accessTokenUri)
-              .set('content-type', 'application/x-www-form-urlencoded')
-              .set('accept', 'json')
-              .send(dataToSend);
+    if (organizationID) {
+      req.set('X-Organization', organizationID)
+    }
+
+    var res = await req.send(dataToSend);
     var token = res.body.access_token;
     var expires_in = res.body.expires_in * 0.8; // needed to change the token before it expires
     if (token !== undefined) {
@@ -161,7 +165,7 @@ async function getClientMqtt(connectionConfig, RED) {
 
 }
 
-async function getClientHttp(connectionConfig) {
+async function getClientHttp(connectionConfig, organizationID) {
 
   if (!connectionConfig || !connectionConfig.credentials) {
     throw new Error("Cannot find cooonection config or credentials.");
@@ -172,7 +176,7 @@ async function getClientHttp(connectionConfig) {
     var clientHttp;
     if (user === -1) {
 
-      var tokenInfo = await getToken(connectionConfig);
+      var tokenInfo = await getToken(connectionConfig, organizationID);
       if (tokenInfo !== undefined) {
         clientHttp = new ArduinoClientHttp.ArduinoClientHttp(tokenInfo.token);
 


### PR DESCRIPTION
To retrieve a token with a correct rate limiting for users in a space, the X-Organization header must be provided in the token request (avoid 429 errors)