### PR TITLE
Fix a glitch of the UI when the node configuration is re-opened after the first configuration

### DIFF
--- a/arduino-iot-cloud.html
+++ b/arduino-iot-cloud.html
@@ -128,13 +128,15 @@
                 $("#node-input-organization").change(() => {
                     const connection = $("#node-input-connection").val();
                     const organization = $("#node-input-organization").val();
-                    this.organization = organization;
+                    
                     if (connection === "_ADD_") {
                         $("#node-input-organization").empty();
                         str = this._("arduino-iot-cloud.config.connection.placeholders.no-conn-selected");
                         $("<option value='" + "" + "' > " + str + "</option>").appendTo("#node-input-thing");
                         $("#node-input-thing").trigger("change");
-                    } else {
+                    } 
+                    if (this.organization != organization) {
+                        this.organization = organization;
                         $("select#node-input-thing").empty();
                         initThings(connection, this._, null, organization);
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "GNU AFFERO GENERAL PUBLIC LICENSE",
       "dependencies": {
-        "@arduino/arduino-iot-client": "github:arduino/iot-client-js",
+        "@arduino/arduino-iot-client": "^3.0.0",
         "@arduino/cbor-js": "github:arduino/cbor-js",
         "async-mutex": "^0.1.4",
         "jws": "^3.2.2",
@@ -32,8 +32,8 @@
       }
     },
     "node_modules/@arduino/arduino-iot-client": {
-      "version": "2.0.5",
-      "resolved": "git+ssh://git@github.com/arduino/iot-client-js.git#bc4991edf2bbd64571e2b52f79d16d392c8d01f2",
+      "version": "3.0.0",
+      "resolved": "git+ssh://git@github.com/arduino/iot-client-js.git#ac903b60b4001cf7282144dc26a73d19f57a7cfa",
       "license": "GPLv3",
       "dependencies": {
         "@babel/cli": "^7.0.0",
@@ -3321,8 +3321,8 @@
       }
     },
     "@arduino/arduino-iot-client": {
-      "version": "git+ssh://git@github.com/arduino/iot-client-js.git#bc4991edf2bbd64571e2b52f79d16d392c8d01f2",
-      "from": "@arduino/arduino-iot-client@arduino/iot-client-js",
+      "version": "git+ssh://git@github.com/arduino/iot-client-js.git#ac903b60b4001cf7282144dc26a73d19f57a7cfa",
+      "from": "@arduino/arduino-iot-client@^3.0.0",
       "requires": {
         "@babel/cli": "^7.0.0",
         "superagent": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   },
   "dependencies": {
-    "@arduino/arduino-iot-client": "github:arduino/iot-client-js",
+    "@arduino/arduino-iot-client": "^3.0.0",
     "@arduino/cbor-js": "github:arduino/cbor-js",
     "async-mutex": "^0.1.4",
     "jws": "^3.2.2",


### PR DESCRIPTION
When a node configuration is edited after the first time, some fields are incorrectly set to empty in the UI.

This PR also fixes a dependency issue, pinning the version of the IoT client lib.